### PR TITLE
Generate callback URI from other config

### DIFF
--- a/AWS/cdk/env.template
+++ b/AWS/cdk/env.template
@@ -6,7 +6,6 @@ SLACK_SIGNING_SECRET=alphanum
 BOT_USER_OAUTH_TOKEN=xoxb-alphahum
 CLIENT_ID=alphanum.apps.googleusercontent.com
 CLIENT_SECRET=alphanum
-# Not a secret, more like config
-REDIRECT_URI='https://slashmeet.my.app.example.com/0_0_1/redirectUri'
+
 
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,6 @@ Slack slash command to create a GMeet meeting
 8. Add an OAuth scope for `users:read`.  It should already have `commands` scope.
 9. Copy the Bot User OAuth Token to the .env file.
 10. Copy the Signing Secret to the .env file.
-11. Set the REDIRECT_URL in the .env file to the same value as step 4.
+11. Set the CUSTOM_DOMAIN_NAME and LAMBDA_VERSION in the .env file to the same values as step 4 (ie https://slashmeet.${CUSTOM_DOMAIN_NAME}/${LAMBDA_VERSION}/redirectUri).
 12. For AWS, create a R53 hosted zone for the subdomain slackapps.example.com.  Update your root DNS with the NS records to do the subdomain delegation.
 13. Add the custom domain name and R53 zone id to the .env file.

--- a/function-src/ts-src/aws/authenticateOrCreateMeetingLambda.ts
+++ b/function-src/ts-src/aws/authenticateOrCreateMeetingLambda.ts
@@ -1,4 +1,3 @@
-import util from 'util';
 import {generateGoogleAuthBlocks} from '../generateGoogleAuthBlocks';
 import {postToResponseUrl} from '../postToResponseUrl';
 import {Auth} from 'googleapis';
@@ -32,10 +31,15 @@ export async function lambdaHandler(event: SlackEvent): Promise<void> {
   if(!clientSecret) {
     throw new Error("Missing env var CLIENT_SECRET");
   }
-  const redirectUri = process.env.REDIRECT_URI;
-  if(!redirectUri) {
-    throw new Error("Missing env var REDIRECT_URI");
+  const customDomainName = process.env.CUSTOM_DOMAIN_NAME;
+  if(!customDomainName) {
+    throw new Error("Missing env var CUSTOM_DOMAIN_NAME");
   }
+  const lambdaVersionIdForURL = process.env.LAMBDA_VERSION_FOR_URL;
+  if(!lambdaVersionIdForURL) {
+    throw new Error("Missing env var LAMBDA_VERSION_FOR_URL");
+  }
+  const redirectUri = `https://slashmeet.${customDomainName}/${lambdaVersionIdForURL}/redirectUri`;
 
   const options: Auth.OAuth2ClientOptions = {
     clientId: clientId,

--- a/function-src/ts-src/aws/authenticationCallbackLambda.ts
+++ b/function-src/ts-src/aws/authenticationCallbackLambda.ts
@@ -32,10 +32,15 @@ export async function lambdaHandler(event: APIGatewayProxyEvent): Promise<APIGat
   if(!clientSecret) {
     throw new Error("Missing env var CLIENT_SECRET");
   }
-  const redirectUri = process.env.REDIRECT_URI;
-  if(!redirectUri) {
-    throw new Error("Missing env var REDIRECT_URI");
+  const customDomainName = process.env.CUSTOM_DOMAIN_NAME;
+  if(!customDomainName) {
+    throw new Error("Missing env var CUSTOM_DOMAIN_NAME");
   }
+  const lambdaVersionIdForURL = process.env.LAMBDA_VERSION_FOR_URL;
+  if(!lambdaVersionIdForURL) {
+    throw new Error("Missing env var LAMBDA_VERSION_FOR_URL");
+  }
+  const redirectUri = `https://slashmeet.${customDomainName}/${lambdaVersionIdForURL}/redirectUri`;
   const options: Auth.OAuth2ClientOptions = {
     clientId: clientId,
     clientSecret: clientSecret,


### PR DESCRIPTION
Use DRY principle: callback URI can be generated from other config.  Reduces potential for config error.