### PR TITLE
Use nonce in state param to mitigate CSRF replay attacks

### DIFF
--- a/cdk/bin/cdk.ts
+++ b/cdk/bin/cdk.ts
@@ -28,6 +28,7 @@ const secretsManagerStack = new SecretsManagerStack(app, 'SlashMeetSecretsManage
 new LambdaStack(app, 'SlashMeetLambdaStack', {
   env: {region},
   slackIdToGCalTokenTable: dynamoDBStack.slackIdToGCalTokenTable,
+  stateTable: dynamoDBStack.stateTable,
   slashMeetSecret: secretsManagerStack.slashMeetSecret,
   lambdaVersion,
   customDomainName,

--- a/cdk/lib/common.ts
+++ b/cdk/lib/common.ts
@@ -24,6 +24,7 @@ export function getEnv(name: string, optional = false): string | undefined {
 
 export interface LambdaStackProps extends StackProps {
   readonly slackIdToGCalTokenTable: dynamodb.Table;
+  readonly stateTable: dynamodb.Table;
   readonly slashMeetSecret: secretsmanager.ISecret;
   readonly lambdaVersion: string;
   readonly customDomainName: string;

--- a/cdk/lib/lambda-stack.ts
+++ b/cdk/lib/lambda-stack.ts
@@ -63,8 +63,9 @@ export class LambdaStack extends Stack {
     });
     // Give the initial response lambda permission to invoke this one
     handleMeetCommandLambda.grantInvoke(handleSlashCommand);
-    // Allow read access to the DyanamoDB table
+    // Allow access to the DyanamoDB tables
     props.slackIdToGCalTokenTable.grantReadData(handleMeetCommandLambda);
+    props.stateTable.grantReadWriteData(handleMeetCommandLambda);
     // Allow read access to the secret it needs
     props.slashMeetSecret.grantRead(handleMeetCommandLambda);
 
@@ -76,8 +77,9 @@ export class LambdaStack extends Stack {
       memorySize: 512,
       ...allLambdaProps
     });
-    // Allow write access to the DyanamoDB table
+    // Allow access to the DyanamoDB tables
     props.slackIdToGCalTokenTable.grantReadWriteData(handleGoogleAuthRedirectLambda);
+    props.stateTable.grantReadWriteData(handleGoogleAuthRedirectLambda);
     // Allow read access to the secret it needs
     props.slashMeetSecret.grantRead(handleGoogleAuthRedirectLambda);
 

--- a/lambda-src/ts-src/generateGoogleAuthBlocks.ts
+++ b/lambda-src/ts-src/generateGoogleAuthBlocks.ts
@@ -1,22 +1,37 @@
 import {Auth} from 'googleapis';
+import crypto from 'crypto';
+import {State, putState} from './stateTable';
 
-export function generateGoogleAuthBlocks(oauth2Client: Auth.OAuth2Client, userId:string) {
+/**
+ * Generate a button for Google login.
+ * CSRF replay attacks are mitigated by using a nonce as the state param in the redirect URL.
+ * The state is the primary key to the info in the SlashMeet_State table which is then queried in the redirect handler.
+ * @param oauth2Client Initialised Google SDK OAuth2Client object
+ * @param slack_user_id Slack user id for the user signing in
+ * @param response_url Response URL for use in the redirect handler to send messages to the Slack user
+ * @returns blocks containing the "Sign in to Google" button
+ */
+export async function generateGoogleAuthBlocks(oauth2Client: Auth.OAuth2Client, slack_user_id: string, response_url: string) {
   const scopes = [
     'https://www.googleapis.com/auth/calendar.events',
     'profile',
   ];
 
-  // TODO - use state to verify callback came from here.
-  const state = {
-    // Slack seems to use snake_case for JSON field names so we'll follow that convention.
-    user_id: userId
+  // Using a nonce for the state mitigates CSRF attacks.
+  const nonce = crypto.randomBytes(16).toString('hex');
+  const state: State = {
+    nonce,
+    slack_user_id,
+    response_url
   };
+
+  await putState(nonce, JSON.stringify(state));
 
   // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
   const url = oauth2Client.generateAuthUrl({
     access_type: 'offline',
     scope: scopes.join(' '),
-    state: encodeURIComponent(JSON.stringify(state)),
+    state: nonce,
     prompt: 'consent'
   });
 

--- a/lambda-src/ts-src/handleGoogleAuthRedirect.ts
+++ b/lambda-src/ts-src/handleGoogleAuthRedirect.ts
@@ -3,54 +3,76 @@ import {generateLoggedInHTML} from './generateLoggedInHTML';
 import {Auth} from 'googleapis';
 import {saveToken} from './tokenStorage';
 import {getSecretValue} from './awsAPI';
+import {deleteState, getState} from './stateTable';
 
 export async function handleGoogleAuthRedirect(event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> {
-  
-  if(!event || !event.queryStringParameters) {
-    throw new Error("No query string parameters in redirect URI");
-  }
-
-  const rawState = event.queryStringParameters["state"] as string;
-  interface State {
-    user_id?: string
-  }
-  const state = JSON.parse(decodeURIComponent(rawState)) as State;
-  const userId = state["user_id"];
-  if(!userId) {
-    throw new Error(`Cannot parse Slack user_id from redirect URL`);
-  }
-
-  const code = event.queryStringParameters["code"] as string;
-  if(!code) {
-    throw new Error(`No "code" query param in redirect URL`);
-  }
-
-  const gcpClientId = await getSecretValue('SlashMeet', 'gcpClientId');
-  const gcpClientSecret = await getSecretValue('SlashMeet', 'gcpClientSecret');
-  const slashMeetUrl = await getSecretValue('SlashMeet', 'slashMeetUrl');
-  const redirectUri = `${slashMeetUrl}/redirectUri`;
-
-  const options: Auth.OAuth2ClientOptions = {
-    clientId: gcpClientId,
-    clientSecret: gcpClientSecret,
-    redirectUri: redirectUri
-  };
-  const oauth2Client = new Auth.OAuth2Client(options);
-  const {tokens} = await oauth2Client.getToken(code);
-  const refreshToken = tokens.refresh_token;
-  if(!refreshToken) {
-    throw new Error("Failed to get refresh token from Google authentication service.");
-  }
-  await saveToken(refreshToken, userId);
-
-  const html = generateLoggedInHTML();
-  const result: APIGatewayProxyResult = {
-    body: html,
-    statusCode: 200,
-    headers: {
-      'Content-Type': 'text/html',
+  try {
+    type QueryStringParameters = {
+      code: string,
+      state: string // This will contain the Slack user ID
+    };
+    const queryStringParameters: QueryStringParameters = event.queryStringParameters as QueryStringParameters;
+    if(!event.queryStringParameters) {
+      throw new Error("Missing event queryStringParameters");
     }
-  };
+    const nonce = queryStringParameters.state;
+    const state = await getState(nonce);
+    if(!state) {
+      throw new Error("Missing state.  Are you a cyber criminal trying a CSRF replay attack?");
+    }
+    await deleteState(nonce);
 
-  return result;
+    const gcpClientId = await getSecretValue('SlashMeet', 'gcpClientId');
+    const gcpClientSecret = await getSecretValue('SlashMeet', 'gcpClientSecret');
+    const slashMeetUrl = await getSecretValue('SlashMeet', 'slashMeetUrl');
+    const redirectUri = `${slashMeetUrl}/redirectUri`;
+
+    const options: Auth.OAuth2ClientOptions = {
+      clientId: gcpClientId,
+      clientSecret: gcpClientSecret,
+      redirectUri: redirectUri
+    };
+    const oauth2Client = new Auth.OAuth2Client(options);
+    const {tokens} = await oauth2Client.getToken(queryStringParameters.code);
+    const refreshToken = tokens.refresh_token;
+    if(!refreshToken) {
+      throw new Error("Failed to get refresh token from Google authentication service.");
+    }
+    await saveToken(refreshToken, state.slack_user_id);
+
+    const html = generateLoggedInHTML();
+    const result: APIGatewayProxyResult = {
+      body: html,
+      statusCode: 200,
+      headers: {
+        'Content-Type': 'text/html',
+      }
+    };
+
+    return result;
+  }
+  catch (error) {
+    console.error(error);
+
+    const html = `
+<!DOCTYPE html>
+<html>
+<body>
+
+<h1>Authentication Failure</h1>
+<p>There was an error.  Please check the logs.</p>
+
+</body>
+</html>
+  `;
+
+    const result: APIGatewayProxyResult = {
+      body: html,
+      statusCode: 200,
+      headers: {
+        'Content-Type': 'text/html',
+      }
+    };
+    return result;
+  }
 }

--- a/lambda-src/ts-src/handleMeetCommand.ts
+++ b/lambda-src/ts-src/handleMeetCommand.ts
@@ -7,24 +7,9 @@ import {getSecretValue} from './awsAPI';
 import {getSlackUserTimeZone} from './getSlackUserTimeZone';
 import {createGoogleMeetMeeting as createGoogleCalendarMeeting} from './createGoogleCalendarMeeting';
 import {MeetingOptions, parseMeetingArgs} from './parseMeetingArgs';
+import {SlashCommandPayload} from './slackTypes';
 
-interface SlackEvent {
-  token: string;
-  team_id: string;
-  team_domain: string;
-  channel_id: string;
-  channel_name: string;
-  user_id: string;
-  user_name: string;
-  command: string;
-  text: string;
-  api_app_id: string;
-  is_enterprise_install: string;
-  response_url: string;
-  trigger_id: string;
-}
-
-export async function handleMeetCommand(event: SlackEvent): Promise<void> {
+export async function handleMeetCommand(event: SlashCommandPayload): Promise<void> {
   const responseUrl = event.response_url;
 
   const gcpClientId = await getSecretValue('SlashMeet', 'gcpClientId');
@@ -42,7 +27,7 @@ export async function handleMeetCommand(event: SlackEvent): Promise<void> {
   const refresh_token = await getToken(event.user_id);
   let blocks = {};
   if(!refresh_token) {
-    const blocks = generateGoogleAuthBlocks(oauth2Client, event.user_id);
+    const blocks = await generateGoogleAuthBlocks(oauth2Client, event.user_id, event.response_url);
     await postToResponseUrl(responseUrl, blocks);
     return;
   } else {

--- a/lambda-src/ts-src/stateTable.ts
+++ b/lambda-src/ts-src/stateTable.ts
@@ -1,0 +1,80 @@
+
+import {DynamoDBClient, PutItemCommand, PutItemCommandInput, QueryCommand, QueryCommandInput, DeleteItemCommand, DeleteItemCommandInput} from '@aws-sdk/client-dynamodb';
+
+// The very useful TTL functionality in DynamoDB means we
+// can set a TTL on storing the refresh token.
+// This is good security and also keeps down storage costs.
+// This state should be fairly short-lived as it's just to
+// mitigage CSRF attacks on the login redirect.
+const TTL_IN_MS = 1000 * 30; // 30 seconds
+const TableName = "SlashMeet_State";
+
+export type State = {
+  nonce: string,
+  slack_user_id: string,
+  response_url: string
+};
+
+/**
+ * Gets the state for the given nonce.
+ * @param nonce 
+ * @returns state or undefined if no state exists for the nonce
+ */
+export async function getState(nonce: string) : Promise<State | undefined>  { 
+  const ddbClient = new DynamoDBClient({});
+
+  const params: QueryCommandInput = {
+    TableName,
+    KeyConditionExpression: "nonce = :nonce",
+    ExpressionAttributeValues: {
+      ":nonce" : {"S" : nonce}
+    }
+  };
+  const data = await ddbClient.send(new QueryCommand(params));
+  const items = data.Items;
+  if(items && items[0] && items[0].state.S) {
+    const state = JSON.parse(items[0].state.S) as State;
+    return state;
+  }
+  else {
+    return undefined;
+  }
+}
+
+export async function deleteState(nonce: string) {
+  const ddbClient = new DynamoDBClient({});
+
+  const params: DeleteItemCommandInput = {
+    TableName,
+    Key: {
+      'nonce': {S: nonce}
+    }
+  };
+
+  const command = new DeleteItemCommand(params);
+
+  await ddbClient.send(command);
+}
+
+/**
+ * Put (ie save new or overwite) state with nonce as the key
+ * @param nonce Key for the table
+ * @param state JSON value
+ */
+export async function putState(nonce: string, state: string) {
+  const now = Date.now();
+  const ttl = new Date(now + TTL_IN_MS);
+
+  const putItemCommandInput: PutItemCommandInput = {
+    TableName,
+    Item: {
+      nonce: {S: nonce},
+      state: {S: state},
+      expiry: {N: `${Math.floor(ttl.getTime() / 1000)}`}
+    }
+  };
+
+  const ddbClient = new DynamoDBClient({});
+
+  await ddbClient.send(new PutItemCommand(putItemCommandInput));
+}


### PR DESCRIPTION
Use nonce as state param as key into SlashMeet_State table.  This mitigates CSRF replay attacks on the Google Login redirect.